### PR TITLE
revert change to test easyconfig for goolf/1.4.10, add gzip as build dep for bzip2 instead

### DIFF
--- a/test/framework/easyconfigs/bzip2-1.0.6-GCC-4.9.2.eb
+++ b/test/framework/easyconfigs/bzip2-1.0.6-GCC-4.9.2.eb
@@ -15,4 +15,6 @@ toolchainopts = {'pic': True}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.bzip.org/%(version)s']
 
+builddependencies = [('gzip', '1.6')]
+
 moduleclass = 'tools'

--- a/test/framework/easyconfigs/goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/goolf-1.4.10.eb
@@ -31,8 +31,6 @@ dependencies = [
     ('OpenMPI', '1.6.4', '', comp),  # part of gompi-1.4.10
     (blaslib, blasver, blas_suff, comp_mpi_tc),
     ('FFTW', '3.3.3', '', comp_mpi_tc),
-]
-builddependencies = [
     ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blas_suff), comp_mpi_tc)
 ]
 

--- a/test/framework/easyconfigs/yeb/bzip2-1.0.6-GCC-4.9.2.yeb
+++ b/test/framework/easyconfigs/yeb/bzip2-1.0.6-GCC-4.9.2.yeb
@@ -22,4 +22,7 @@ sources:
 source_urls:
     - http://www.bzip.org/%(version)s
 
+builddependencies:
+    - gzip: 1.6
+
 moduleclass: tools

--- a/test/framework/easyconfigs/yeb/goolf-1.4.10.yeb
+++ b/test/framework/easyconfigs/yeb/goolf-1.4.10.yeb
@@ -37,8 +37,6 @@ dependencies:
       toolchain: *comp_mpi_tc
     - FFTW: 3.3.3
       toolchain: *comp_mpi_tc
-
-builddependencies:
     - ScaLAPACK: 2.0.2
       versionsuffix: !join [-, *blas, *blas_suff]
       toolchain: *comp_mpi_tc


### PR DESCRIPTION
@Caylo I prefer changing the test easyconfigs in a way that "makes sense" rather than making a random change to cover the fix for `builddependencies`.
