### PR TITLE
rework support for incl. easyconfigs for deps in --new-pr/--update-pr to avoid cyclic import

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -52,6 +52,7 @@ from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
 from easybuild.tools.filetools import find_easyconfigs, which, write_file
+from easybuild.tools.github import fetch_easyconfigs_from_pr, download_repo
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.multidiff import multidiff
 from easybuild.tools.ordereddict import OrderedDict
@@ -547,4 +548,3 @@ def dump_env_script(easyconfigs):
         restore_env(orig_env)
 
 
-from easybuild.tools.github import fetch_easyconfigs_from_pr, download_repo

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -321,6 +321,10 @@ def init_build_options(build_options=None, cmdline_options=None):
             cmdline_options.force = True
             retain_all_deps = True
 
+        if cmdline_options.new_pr or cmdline_options.update_pr:
+            _log.info("Retaining all dependencies of specified easyconfigs to create/update pull request")
+            retain_all_deps = True
+
         auto_ignore_osdeps_options = [cmdline_options.check_conflicts, cmdline_options.dep_graph,
                                       cmdline_options.dry_run, cmdline_options.dry_run_short,
                                       cmdline_options.extended_dry_run, cmdline_options.dump_env_script]

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -55,7 +55,6 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import apply_patch, det_patched_files, download_file, extract_file
 from easybuild.tools.filetools import is_patch_file, mkdir, read_file, which, write_file
 from easybuild.tools.modules import modules_tool
-from easybuild.tools.robot import resolve_dependencies
 from easybuild.tools.systemtools import UNKNOWN, get_tool_version
 from easybuild.tools.utilities import only_if_module_is_available
 
@@ -577,7 +576,7 @@ def setup_repo(git_repo, target_account, target_repo, branch_name, silent=False,
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def _easyconfigs_pr_common(paths, start_branch=None, pr_branch=None, target_account=None, commit_msg=None):
+def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, target_account=None, commit_msg=None):
     """
     Common code for new_pr and update_pr functions:
     * check whether all supplied paths point to existing files
@@ -587,11 +586,12 @@ def _easyconfigs_pr_common(paths, start_branch=None, pr_branch=None, target_acco
     * stage/commit all files in PR branch
     * push PR branch to GitHub (to account specified by --github-user)
 
-    @paths: list of paths that will be used to create/update PR
-    @start_branch: name of branch to start from
-    @pr_branch: name of branch to push to GitHub
-    @target_account: name of target GitHub account for PR
-    @commit_msg: commit message to use
+    :param paths: list of paths that will be used to create/update PR
+    :param ecs: list of parsed easyconfigs, incl. for dependencies (if robot is enabled)
+    :param start_branch: name of branch to start from
+    :param pr_branch: name of branch to push to GitHub
+    :param target_account: name of target GitHub account for PR
+    :param commit_msg: commit message to use
     """
     # we need files to create the PR with
     if paths:
@@ -667,24 +667,18 @@ def _easyconfigs_pr_common(paths, start_branch=None, pr_branch=None, target_acco
         'new': [],
     }
 
-    # if robot is on, resolve dependencies
-    if build_option('robot'):
-        try:
-            deps = resolve_dependencies([process_easyconfig(ec)[0] for ec in paths], modules_tool())
-        except EasyBuildError as err:
-            raise EasyBuildError("Couldn't resolve dependencies within the current robot search path. "
-                                 "Try specifying the robot path with option -r. (%s)" % err)
+    # include missing easyconfigs for dependencies, if robot is enabled
+    if len(paths) != len(ecs):
 
-        # don't save info on dependencies
         abs_paths = [os.path.abspath(path) for path in paths]
-        dep_paths = [dep['spec'] for dep in deps if dep['spec'] not in abs_paths]
-        all_dep_info = copy_easyconfigs(dep_paths, os.path.join(git_working_dir, pr_target_repo))
+        dep_paths = [ec['spec'] for ec in ecs if ec['spec'] not in abs_paths]
+        all_dep_info = copy_easyconfigs(dep_paths, target_dir)
 
-        # only consider new dependency files
-        for i in range(0, len(all_dep_info['ecs'])):
-            if all_dep_info['new'][i]:
+        # only consider new easyconfig files for dependencies
+        for idx in range(len(all_dep_info['ecs'])):
+            if all_dep_info['new'][idx]:
                 for key in dep_info.keys():
-                    dep_info[key].append(all_dep_info[key][i])
+                    dep_info[key].append(all_dep_info[key][idx])
 
     # checkout target branch
     if pr_branch is None:
@@ -693,7 +687,6 @@ def _easyconfigs_pr_common(paths, start_branch=None, pr_branch=None, target_acco
         else:
             label = ''.join(random.choice(string.letters) for _ in range(10))
         pr_branch = '%s_new_pr_%s' % (time.strftime("%Y%m%d%H%M%S"), label)
-
 
     # create branch to commit to and push;
     # use force to avoid errors if branch already exists (OK since this is a local temporary copy of the repo)
@@ -847,8 +840,16 @@ def find_software_name_for_patch(patch_name):
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def new_pr(paths, title=None, descr=None, commit_msg=None):
-    """Open new pull request using specified files."""
+def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
+    """
+    Open new pull request using specified files
+
+    :param paths: list of paths that will be used to create/update PR
+    :param ecs: list of parsed easyconfigs, incl. for dependencies (if robot is enabled)
+    :param title: title to use for pull request
+    :param descr: description to use for description
+    :param commit_msg: commit message to use
+    """
 
     _log.experimental("Opening new pull request for: %s", ', '.join(paths))
 
@@ -868,7 +869,8 @@ def new_pr(paths, title=None, descr=None, commit_msg=None):
         raise EasyBuildError("GitHub token for user '%s' must be available to use --new-pr", github_user)
 
     # create branch, commit files to it & push to GitHub
-    file_info, deleted_paths, git_repo, branch, diff_stat = _easyconfigs_pr_common(paths, pr_branch=pr_branch_name,
+    file_info, deleted_paths, git_repo, branch, diff_stat = _easyconfigs_pr_common(paths, ecs,
+                                                                                   pr_branch=pr_branch_name,
                                                                                    target_account=pr_target_account,
                                                                                    commit_msg=commit_msg)
 
@@ -937,8 +939,15 @@ def new_pr(paths, title=None, descr=None, commit_msg=None):
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def update_pr(pr, paths, commit_msg=None):
-    """Update specified pull request using specified files."""
+def update_pr(pr, paths, ecs, commit_msg=None):
+    """
+    Update specified pull request using specified files
+
+    :param pr: ID of pull request to update
+    :param paths: list of paths that will be used to create/update PR
+    :param ecs: list of parsed easyconfigs, incl. for dependencies (if robot is enabled)
+    :param commit_msg: commit message to use
+    """
 
     _log.experimental("Updating pull request #%s with %s", pr, paths)
 
@@ -961,7 +970,7 @@ def update_pr(pr, paths, commit_msg=None):
     github_target = '%s/%s' % (pr_target_account, pr_target_repo)
     print_msg("Determined branch name corresponding to %s PR #%s: %s" % (github_target, pr, branch), log=_log)
 
-    _, _, _, _, diff_stat = _easyconfigs_pr_common(paths, start_branch=branch, pr_branch=branch,
+    _, _, _, _, diff_stat = _easyconfigs_pr_common(paths, ecs, start_branch=branch, pr_branch=branch,
                                                    target_account=account, commit_msg=commit_msg)
 
     print_msg("Overview of changes:\n%s\n" % diff_stat, log=_log, prefix=False)


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-framework/pull/1855

this needs a bit more love, a couple of tests are broken:

```
$ python -O -m test.framework.options

..............F........................EFE......................
======================================================================
ERROR: test_new_pr_delete (__main__.CommandLineOptionsTest)
Test use of --new-pr to delete easyconfigs.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/options.py", line 2390, in test_new_pr_delete
    self.eb_main(args, do_build=True, raise_error=True, testing=False)
  File "test/framework/utilities.py", line 292, in eb_main
    raise myerr
EasyBuildError: "Can't find path /Users/kehoste/work/easybuild-framework/:bzip2-1.0.6.eb"

======================================================================
ERROR: test_new_update_pr (__main__.CommandLineOptionsTest)
Test use of --new-pr (dry run only).
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/options.py", line 2288, in test_new_update_pr
    self.eb_main(args, do_build=True, raise_error=True, testing=False)
  File "test/framework/utilities.py", line 292, in eb_main
    raise myerr
EasyBuildError: 'Failed to process easyconfig /Users/kehoste/work/easybuild-framework/test/framework/sandbox/sources/toy/toy-0.0_typo.patch: NO LONGER SUPPORTED since v2.0: Fallback to default easyblock ConfigureMake (from easybuild.easyblocks.generic.configuremake); use "easyblock = \'ConfigureMake\'" in easyconfig file?; see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information'

======================================================================
FAIL: test_empty_pr (__main__.CommandLineOptionsTest)
Test use of --new-pr (dry run only) with no changes
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/options.py", line 2481, in test_empty_pr
    self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, do_build=True, raise_error=True)
  File "/Users/kehoste/.pypkgs/lib/python2.7/site-packages/vsc_install-0.10.6-py2.7.egg/vsc/install/testing.py", line 115, in assertErrorRegex
    self.assertTrue(False, "Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
AssertionError: Expected errors with eb_main(['--new-pr', '--experimental', '/var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-XgF9B_/eb-sn9Y7J/zlib-1.2.8.eb', '-D', '--github-user=easybuild_test'], raise_error=True, do_build=True) call should occur

======================================================================
FAIL: test_new_pr_dependencies (__main__.CommandLineOptionsTest)
Test use of --new-pr with automatic dependency lookup.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/options.py", line 2455, in test_new_pr_dependencies
    self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
AssertionError: Pattern '^\* overview of changes:' found in: == temporary log file in case of crash /var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-XgF9B_/eb-pfw52I/eb-test-ewGZLu.log
Dry run: printing build status of easyconfigs and dependencies
CFGS=/var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-XgF9B_/eb-pfw52I
 * [ ] $CFGS/bar-2.0.eb (module: bar/2.0)
 * [ ] $CFGS/foo-1.0.eb (module: foo/1.0)
== Keeping temporary log file(s) /var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-XgF9B_/eb-pfw52I/eb-test-ewGZLu.log* and directory /var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-XgF9B_/eb-pfw52I/eb-0UP25T/eb-UcRmd2.


----------------------------------------------------------------------
Ran 64 tests in 128.401s

FAILED (failures=2, errors=2)
```
